### PR TITLE
bug: 카카오 프로필 데이터 타입 크기 수정

### DIFF
--- a/backend/src/main/java/solid/backend/entity/Member.java
+++ b/backend/src/main/java/solid/backend/entity/Member.java
@@ -22,7 +22,7 @@ public class Member {
     @Comment("회원 ID")
     private String memberId;
 
-    @Column(name = "member_profile", length = 100)
+    @Column(name = "member_profile", length = 200)
     @Comment("프로필 이미지")
     private String memberProfile;
 


### PR DESCRIPTION
## 변경 사항 설명
카카오 프로필 데이터 타입 크기 수정

## 관련 이슈
#21 

## 체크리스트
- [ ] 필요한 테스트를 추가했습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)

## 스크린샷 (UI 변경사항이 있는 경우)
x

## 리뷰어를 위한 참고사항
member 테이블 프로필 데이터 타입 크기 100 -> 200 수정