### PR TITLE
refactor: 카카오 이미지 다운로드 후 저장 로직 추가

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,6 +6,7 @@ src/main/java/solid/backend
 - login : 회원 관리
 - common : 공통 기능
   - FileManager : 파일 관리 모듈
+  - SimpleMultipartFile : MultipartFile 구현체
 - config: 설정파일
   - QueryDSLConfig: QueryDSL 빈 등록
   - FileStorageConfig : 파일 설정 값 관리

--- a/backend/src/main/java/solid/backend/common/FileManager.java
+++ b/backend/src/main/java/solid/backend/common/FileManager.java
@@ -131,7 +131,7 @@ public class FileManager {
                 }
 
                 // 3. MultipartFile 변환 후 반환
-                return new MockMultipartFile(
+                return new SimpleMultipartFile(
                         "file",
                         extension,
                         "image/" + extension.replace(".", ""),

--- a/backend/src/main/java/solid/backend/common/FileManager.java
+++ b/backend/src/main/java/solid/backend/common/FileManager.java
@@ -9,6 +9,8 @@ import solid.backend.config.FileStorageConfig;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 import java.util.UUID;
 
 @Slf4j
@@ -40,8 +42,8 @@ public class FileManager {
             }
 
             String lowerName = originalName.toLowerCase();
-            if (!lowerName.endsWith(".jpg") && !lowerName.endsWith(".png")) {
-                throw new IllegalArgumentException("허용되지 않는 파일 형식입니다. (jpg, png만 가능)");
+            if (!lowerName.endsWith(".jpg") && !lowerName.endsWith(".png") && !lowerName.endsWith(".jpeg")) {
+                throw new IllegalArgumentException("허용되지 않는 파일 형식입니다. (jpg, png, jpeg만 가능)");
             }
 
             // 파일명 길이 제한
@@ -104,4 +106,41 @@ public class FileManager {
         String processedUrl = ServletUriComponentsBuilder.fromCurrentContextPath().path("/solid").toUriString();
         return processedUrl + fileImgUrl;
     }
+
+    /**
+     * 설명 : 카카오 이미지 다운로드 후 MultipartFile 변환
+     * @param imageUrl
+     * @return MultipartFile
+     */
+    public MultipartFile toMultipartFile(String imageUrl) {
+        try {
+            // 1. 카카오 이미지 다운로드
+            URL url = new URL(imageUrl);
+            try (InputStream inputStream = url.openStream()) {
+                byte[] bytes = inputStream.readAllBytes();
+
+                // 2. 확장자 추출
+                String lowerUrl = imageUrl.toLowerCase();
+                String extension = ".jpg";
+                if (lowerUrl.endsWith(".png")) {
+                    extension = ".png";
+                } else if (lowerUrl.endsWith(".jpeg")) {
+                    extension = ".jpeg";
+                } else if (lowerUrl.endsWith(".jpg")) {
+                    extension = ".jpg";
+                }
+
+                // 3. MultipartFile 변환 후 반환
+                return new MockMultipartFile(
+                        "file",
+                        extension,
+                        "image/" + extension.replace(".", ""),
+                        bytes
+                );
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("카카오 프로필 이미지 변환 실패: " + e.getMessage(), e);
+        }
+    }
+
 }

--- a/backend/src/main/java/solid/backend/common/MockMultipartFile.java
+++ b/backend/src/main/java/solid/backend/common/MockMultipartFile.java
@@ -1,0 +1,59 @@
+package solid.backend.common;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public class MockMultipartFile implements MultipartFile {
+
+    private String name;
+    private String originalFilename;
+    private String contentType;
+    private byte[] bytes;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return bytes == null || bytes.length == 0;
+    }
+
+    @Override
+    public long getSize() {
+        return bytes.length;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        return bytes;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return new ByteArrayInputStream(bytes);
+    }
+
+    @Override
+    public void transferTo(java.io.File dest) throws IOException {
+        java.nio.file.Files.write(dest.toPath(), bytes);
+    }
+}

--- a/backend/src/main/java/solid/backend/common/SimpleMultipartFile.java
+++ b/backend/src/main/java/solid/backend/common/SimpleMultipartFile.java
@@ -10,7 +10,7 @@ import java.io.InputStream;
 
 @AllArgsConstructor
 @NoArgsConstructor
-public class MockMultipartFile implements MultipartFile {
+public class SimpleMultipartFile implements MultipartFile {
 
     private String name;
     private String originalFilename;

--- a/backend/src/main/java/solid/backend/login/service/LoginServiceImpl.java
+++ b/backend/src/main/java/solid/backend/login/service/LoginServiceImpl.java
@@ -10,8 +10,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
 import solid.backend.Jwt.AccessToken;
 import solid.backend.Jwt.JwtUtil;
+import solid.backend.common.FileManager;
 import solid.backend.entity.Member;
 import solid.backend.jpaRepository.MemberRepository;
 import solid.backend.login.dto.LoginApiDto;
@@ -28,6 +30,7 @@ public class LoginServiceImpl implements LoginService {
     private final LoginApiDto loginApiDto;
     private final MemberRepository loginRepository;
     private final JwtUtil jwtUtil;
+    private final FileManager fileManager;
 
     /**
      * 설명 : 카카오 로그인
@@ -107,9 +110,12 @@ public class LoginServiceImpl implements LoginService {
         final String email = (String) kakaoAccount.get("email");
 
         // 프로필 이미지
-        final String newProfileImage = (profile != null)
-                ? (String) profile.get("profile_image_url")
-                : null;
+        String profileImage = null;
+        if (profile != null && profile.get("profile_image_url") != null) {
+            MultipartFile kakaoImage = fileManager.toMultipartFile((String) profile.get("profile_image_url"));
+            profileImage = fileManager.addFile(kakaoImage, "profile");
+        }
+        final String newProfileImage = profileImage;
 
         // 3. 회원 정보 확인 및 없으면 등록
         Member member = loginRepository.findById(id)


### PR DESCRIPTION
## 변경 사항 설명
기존에 카카오 이미지 주소를 db에 저장함 -> 카카오 이미지 다운로드 후 주소 가공하여 db에 저장 로직 추가

## 관련 이슈
#40 

## 체크리스트
- [ ] 필요한 테스트를 추가했습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우)

## 스크린샷 (UI 변경사항이 있는 경우)
x

## 리뷰어를 위한 참고사항
회원 이미지 조회하는 로직 작성하셨던 분들 Filemanager로 url 가공해서 조회하도록 수정해주세요.