### PR TITLE
fix: 캡슐 삭제 로직 수정 

### DIFF
--- a/backend/src/main/java/solid/backend/capsule/cndt/service/CapsuleCndtServiceImpl.java
+++ b/backend/src/main/java/solid/backend/capsule/cndt/service/CapsuleCndtServiceImpl.java
@@ -10,6 +10,7 @@ import solid.backend.entity.Capsule;
 import solid.backend.entity.CapsuleCNDT;
 import solid.backend.entity.TeamMember;
 import solid.backend.entity.TeamMemberId;
+import solid.backend.jpaRepository.AlarmRepository;
 import solid.backend.jpaRepository.CapsuleCndtRepository;
 import solid.backend.jpaRepository.CapsuleRepository;
 import solid.backend.jpaRepository.TeamMemberRepository;
@@ -25,6 +26,7 @@ public class CapsuleCndtServiceImpl implements CapsuleCndtService {
     private final CapsuleCndtRepository capsuleCndtRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final FileManager fileManager;
+    private final AlarmRepository alarmRepository;
 
 
     /**
@@ -103,6 +105,9 @@ public class CapsuleCndtServiceImpl implements CapsuleCndtService {
         Capsule capsule = capsuleRepository.findById(capId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 캡슐이 없습니다."));
 
+        // 관련 알람 먼저 삭제 (외래키 제약 조건 해결)
+        alarmRepository.deleteByCapsule(capsule);
+        
         fileManager.deleteFile(capsule.getCapImg());
         capsuleRepository.deleteById(capId);
     }

--- a/backend/src/main/java/solid/backend/capsule/date/service/CapsuleDateServiceImpl.java
+++ b/backend/src/main/java/solid/backend/capsule/date/service/CapsuleDateServiceImpl.java
@@ -9,6 +9,7 @@ import solid.backend.common.FileManager;
 import solid.backend.entity.Capsule;
 import solid.backend.entity.TeamMember;
 import solid.backend.entity.TeamMemberId;
+import solid.backend.jpaRepository.AlarmRepository;
 import solid.backend.jpaRepository.CapsuleRepository;
 import solid.backend.jpaRepository.TeamMemberRepository;
 
@@ -22,6 +23,7 @@ public class CapsuleDateServiceImpl implements CapsuleDateService {
     private final CapsuleRepository capsuleRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final FileManager fileManager;
+    private final AlarmRepository alarmRepository;
 
     /**
      * 설명: 캡슐 조회
@@ -91,6 +93,9 @@ public class CapsuleDateServiceImpl implements CapsuleDateService {
         Capsule capsule = capsuleRepository.findById(capId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 캡슐이 없습니다."));
 
+        // 관련 알람 먼저 삭제 (외래키 제약 조건 해결)
+        alarmRepository.deleteByCapsule(capsule);
+        
         fileManager.deleteFile(capsule.getCapImg());
         capsuleRepository.deleteById(capId);
     }

--- a/backend/src/main/java/solid/backend/capsule/space/service/CapsuleSpaceServiceImpl.java
+++ b/backend/src/main/java/solid/backend/capsule/space/service/CapsuleSpaceServiceImpl.java
@@ -12,6 +12,7 @@ import solid.backend.capsule.cndt.service.CapsuleCndtService;
 import solid.backend.common.FileManager;
 import solid.backend.entity.Capsule;
 import solid.backend.entity.Member;
+import solid.backend.jpaRepository.AlarmRepository;
 import solid.backend.jpaRepository.CapsuleRepository;
 import solid.backend.jpaRepository.MemberRepository;
 import solid.backend.exception.CustomException;
@@ -32,6 +33,7 @@ public class CapsuleSpaceServiceImpl implements CapsuleSpaceService {
     private final CapsuleDateService capsuleDateService;
     private final CapsuleCndtService capsuleCndtService;
     private final FileManager fileManager;
+    private final AlarmRepository alarmRepository;
     
     @Override
     public CapsuleSpaceResponseDto getCapsuleSpace(String memberId) {
@@ -77,10 +79,15 @@ public class CapsuleSpaceServiceImpl implements CapsuleSpaceService {
         log.info("캡슐 삭제 시작 - capsuleId: {}, teamId: {}, memberId: {}", 
                 capsuleId, capsule.getTeam().getTeamId(), memberId);
         
+        // 모든 캡슐 타입에 대해 관련 알람 먼저 삭제 (외래키 제약 조건 해결)
+        alarmRepository.deleteByCapsule(capsule);
+        log.debug("캡슐 관련 알람 삭제 완료 - capsuleId: {}", capsuleId);
+        
         // 캡슐 타입에 따른 삭제 처리
         if (capsule.getCapsuleLocation() != null) {
             // 위치 캡슐인 경우 - 파일 삭제 후 캡슐 삭제
             log.debug("위치 캡슐 삭제 - capsuleId: {}", capsuleId);
+            
             if (capsule.getCapImg() != null) {
                 fileManager.deleteFile(capsule.getCapImg());
                 log.debug("캡슐 이미지 파일 삭제 완료 - file: {}", capsule.getCapImg());

--- a/backend/src/main/java/solid/backend/jpaRepository/AlarmRepository.java
+++ b/backend/src/main/java/solid/backend/jpaRepository/AlarmRepository.java
@@ -2,6 +2,7 @@ package solid.backend.jpaRepository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import solid.backend.entity.Alarm;
+import solid.backend.entity.Capsule;
 import solid.backend.entity.Member;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Integer> {
@@ -11,4 +12,10 @@ public interface AlarmRepository extends JpaRepository<Alarm, Integer> {
      * @param member
      */
     void deleteByMember(Member member);
+
+    /**
+     * 설명 : 캡슐 ID로 알람 삭제
+     * @param capsule
+     */
+    void deleteByCapsule(Capsule capsule);
 }


### PR DESCRIPTION
## 변경 사항 설명
알람 테이블이 추가됨으로 인해 외래키 제약조건으로 인해 캡슐이 삭제가 안되는 문제발생
알람삭제 -> 파일삭제 -> 캡슐삭제순서로 처리를 하여 외래키 제약조건 문제 해결

## 관련 이슈
#88 

